### PR TITLE
Get rid of storing class names in db instead delegate it to converter

### DIFF
--- a/eve-converters/converter-moshi/src/main/java/uncmn/eve/converter/moshi/MoshiConverter.java
+++ b/eve-converters/converter-moshi/src/main/java/uncmn/eve/converter/moshi/MoshiConverter.java
@@ -21,9 +21,10 @@ public class MoshiConverter implements Converter {
   }
 
   /**
-   * @param converterKey Unique converter key.
+   * @param converterKey Unique converter key. This is the key that will be persisted in the db.
+   * @param converterClass Class that should be mapped for this key.
    */
-  public <T> void addConverter(String converterKey, Class<T> converterClass) {
+  public <T> void map(String converterKey, Class<T> converterClass) {
     converterMappings.put(converterKey, converterClass);
   }
 
@@ -75,10 +76,10 @@ public class MoshiConverter implements Converter {
   }
 
   @Override public byte[] serialize(Object object) {
-    return serialize(object, converterMappings.get(converterKey(object)));
+    return serialize(object, converterMappings.get(mapping(object)));
   }
 
-  @Override public String converterKey(Object object) {
+  @Override public String mapping(Object object) {
     for (Map.Entry<String, Class<?>> item : converterMappings.entrySet()) {
       boolean bool = item.getValue().isAssignableFrom(object.getClass());
       if (bool) {

--- a/eve-converters/converter-moshi/src/main/java/uncmn/eve/converter/moshi/MoshiConverter.java
+++ b/eve-converters/converter-moshi/src/main/java/uncmn/eve/converter/moshi/MoshiConverter.java
@@ -2,6 +2,8 @@ package uncmn.eve.converter.moshi;
 
 import com.squareup.moshi.Moshi;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import okio.Buffer;
 import uncmn.eve.Converter;
 
@@ -12,9 +14,17 @@ import uncmn.eve.Converter;
 public class MoshiConverter implements Converter {
 
   Moshi moshi;
+  private HashMap<String, Class<?>> converterMappings = new HashMap<>();
 
   MoshiConverter(Moshi moshi) {
     this.moshi = moshi;
+  }
+
+  /**
+   * @param converterKey Unique converter key.
+   */
+  public <T> void addConverter(String converterKey, Class<T> converterClass) {
+    converterMappings.put(converterKey, converterClass);
   }
 
   /**
@@ -25,7 +35,7 @@ public class MoshiConverter implements Converter {
     return new MoshiConverter(moshi);
   }
 
-  @SuppressWarnings("unchecked") @Override public <T> T deserialize(byte[] data, Class<T> type) {
+  public <T> T deserialize(byte[] data, Class<T> type) {
     if (moshi == null || data == null || type == null) {
       return null;
     }
@@ -41,7 +51,7 @@ public class MoshiConverter implements Converter {
     return null;
   }
 
-  @SuppressWarnings("unchecked") @Override public byte[] serialize(Object object, Class type) {
+  public byte[] serialize(Object object, Class type) {
     Buffer buffer = new Buffer();
     try {
       moshi.adapter(type).toJson(buffer, object);
@@ -50,5 +60,31 @@ public class MoshiConverter implements Converter {
       e.printStackTrace();
     }
     return new byte[0];
+  }
+
+  /**
+   *
+   * @param data
+   * @param converterKey
+   * @param <T>
+   * @return
+   */
+  @Override @SuppressWarnings("unchecked") public <T> T deserialize(byte[] data,
+      String converterKey) {
+    return deserialize(data, (Class<T>) converterMappings.get(converterKey));
+  }
+
+  @Override public byte[] serialize(Object object) {
+    return serialize(object, converterMappings.get(converterKey(object)));
+  }
+
+  @Override public String converterKey(Object object) {
+    for (Map.Entry<String, Class<?>> item : converterMappings.entrySet()) {
+      boolean bool = item.getValue().isAssignableFrom(object.getClass());
+      if (bool) {
+        return item.getKey();
+      }
+    }
+    return null;
   }
 }

--- a/eve-stores/store-sql/src/main/java/uncmn/eve/store/sql/SqlStore.java
+++ b/eve-stores/store-sql/src/main/java/uncmn/eve/store/sql/SqlStore.java
@@ -63,15 +63,13 @@ public class SqlStore extends Store {
       boolean isPrimitive =
           cursor.getInt(cursor.getColumnIndexOrThrow(ValueQuery.IS_PRIMITIVE)) == 1;
       String c = cursor.getString(cursor.getColumnIndexOrThrow(ValueQuery.TYPE));
-
-      Class<?> type = Types.getClassType(c, isPrimitive);
-
-      if (type == null) {
-        return null;
-      }
-
       byte[] value = cursor.getBlob(cursor.getColumnIndexOrThrow(ValueQuery.VALUE));
-      return convert(value, type);
+      if (isPrimitive) {
+        Class<?> type = Types.getClassType(c, isPrimitive);
+        return convert(value, type);
+      } else {
+        return (T) convert(value, c);
+      }
     }
     return null;
   }

--- a/eve-stores/store-sql/src/main/java/uncmn/eve/store/sql/SqlStoreOpenHelper.java
+++ b/eve-stores/store-sql/src/main/java/uncmn/eve/store/sql/SqlStoreOpenHelper.java
@@ -9,7 +9,7 @@ import android.database.sqlite.SQLiteOpenHelper;
  */
 public class SqlStoreOpenHelper extends SQLiteOpenHelper {
 
-  static final String DB_NAME = "eve_kv.store";
+  static final String DB_NAME = "eve_kv_store.db";
   static final int DB_VERSION = 1;
 
   public SqlStoreOpenHelper(Context context) {

--- a/eve/src/main/java/uncmn/eve/Converter.java
+++ b/eve/src/main/java/uncmn/eve/Converter.java
@@ -5,7 +5,21 @@ package uncmn.eve;
  */
 public interface Converter {
 
-  <T> T deserialize(byte[] data, Class<T> type);
+  /**
+   * @param data data bytes that are serialized to disk.
+   * @param converterKey Converter key.
+   * @param <T> Type.
+   * @return Deserialized object of type <T>.
+   */
+  <T> T deserialize(byte[] data, String converterKey);
 
-  byte[] serialize(Object object, Class type);
+  /**
+   * @param object Object to be serialized into byte[].
+   */
+  byte[] serialize(Object object);
+
+  /**
+   * @return Converter key of a given object. Null if cannot be determined.
+   */
+  String converterKey(Object object);
 }

--- a/eve/src/main/java/uncmn/eve/Converter.java
+++ b/eve/src/main/java/uncmn/eve/Converter.java
@@ -21,5 +21,5 @@ public interface Converter {
   /**
    * @return Converter key of a given object. Null if cannot be determined.
    */
-  String converterKey(Object object);
+  String mapping(Object object);
 }

--- a/eve/src/main/java/uncmn/eve/Operations.java
+++ b/eve/src/main/java/uncmn/eve/Operations.java
@@ -5,19 +5,51 @@ package uncmn.eve;
  */
 public interface Operations {
 
+  /**
+   * @param key Unique key string.
+   * @param value int value.
+   */
   void set(String key, int value);
 
+  /**
+   * @param key Unique key string.
+   * @param value float value.
+   */
   void set(String key, float value);
 
+  /**
+   * @param key Unique key string.
+   * @param value double value.
+   */
   void set(String key, double value);
 
+  /**
+   * @param key Unique key string.
+   * @param value boolean value.
+   */
   void set(String key, boolean value);
 
+  /**
+   * @param key Unique key string.
+   * @param value char value.
+   */
   void set(String key, char value);
 
+  /**
+   * @param key Unique key string.
+   * @param value byte value.
+   */
   void set(String key, byte value);
 
+  /**
+   * @param key Unique key string.
+   * @param value String value.
+   */
   void set(String key, String value);
 
-  void set(String key, Object value, Class type);
+  /**
+   * @param key Unique key string.
+   * @param value An object that can be converted with {@linkplain Converter}.
+   */
+  void set(String key, Object value);
 }

--- a/eve/src/main/java/uncmn/eve/Store.java
+++ b/eve/src/main/java/uncmn/eve/Store.java
@@ -90,7 +90,7 @@ public abstract class Store implements Operations {
    * @param object Object
    */
   @Override public void set(String key, Object object) {
-    String converterKey = converter.converterKey(object);
+    String converterKey = converter.mapping(object);
     if (converterKey == null) {
       throw new RuntimeException("Object cannot be converted");
     }

--- a/eve/src/main/java/uncmn/eve/Store.java
+++ b/eve/src/main/java/uncmn/eve/Store.java
@@ -1,5 +1,6 @@
 package uncmn.eve;
 
+import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
@@ -87,10 +88,13 @@ public abstract class Store implements Operations {
    *
    * @param key is a {@link String}, NotNull and Unique
    * @param object Object
-   * @param type {@link Class}
    */
-  @Override public void set(String key, Object object, Class type) {
-    set(key, value(converter.serialize(object, type), type));
+  @Override public void set(String key, Object object) {
+    String converterKey = converter.converterKey(object);
+    if (converterKey == null) {
+      throw new RuntimeException("Object cannot be converted");
+    }
+    set(key, value(converter.serialize(object), converterKey));
   }
 
   /**
@@ -113,6 +117,28 @@ public abstract class Store implements Operations {
   }
 
   /**
+   * Build {@link Value}.
+   *
+   * @param value byte array of the Object
+   * @param type {@link Class}
+   * @return {@link Value}
+   */
+  protected Value value(byte[] value, String type) {
+    return Value.builder().value(value).type(type).build();
+  }
+
+  /**
+   * @param value byte[] to be converted.
+   * @param converterKey Converter key.
+   * @param <T> type to be converted to.
+   * @return converted object.
+   */
+  @SuppressWarnings({ "unchecked", "UnusedDeclaration" }) protected <T> T convert(byte[] value,
+      String converterKey) {
+    return (T) converter.deserialize(value, converterKey);
+  }
+
+  /**
    * Convert the byte array into {@link Class} type.
    *
    * @param value byte array
@@ -121,9 +147,9 @@ public abstract class Store implements Operations {
    * @return generic Class type
    */
   @SuppressWarnings({ "unchecked", "UnusedDeclaration" }) protected <T> T convert(byte[] value,
-      Class type) {
+      Type type) {
 
-    if (value == null | type == null) {
+    if (type == null) {
       return null;
     }
 
@@ -154,7 +180,7 @@ public abstract class Store implements Operations {
     }
 
     if (object == null) {
-      return (T) converter.deserialize(value, type);
+      return null;
     } else {
       return (T) object;
     }

--- a/eve/src/main/java/uncmn/eve/Types.java
+++ b/eve/src/main/java/uncmn/eve/Types.java
@@ -83,6 +83,7 @@ public final class Types {
 
   /**
    * Get class type for a primitive.
+   *
    * @param c class name string.
    * @param isPrimitive if is primitive.
    * @return Typed class instance.
@@ -106,12 +107,6 @@ public final class Types {
         cls = long.class;
       } else if (byte.class.getName().equals(c)) {
         cls = byte.class;
-      }
-    } else {
-      try {
-        cls = Class.forName(c);
-      } catch (ClassNotFoundException e) {
-        e.printStackTrace();
       }
     }
     return cls;

--- a/eve/src/main/java/uncmn/eve/Value.java
+++ b/eve/src/main/java/uncmn/eve/Value.java
@@ -44,6 +44,7 @@ public class Value {
 
     byte[] value;
     Type type;
+    String stringType;
     boolean isPrimitive;
 
     public Builder value(byte[] value) {
@@ -56,20 +57,29 @@ public class Value {
       return this;
     }
 
+    public Builder type(String type) {
+      this.stringType = type;
+      return this;
+    }
+
     /**
      * Build the value object.
      *
      * @return Value object.
      */
     public Value build() {
-      if (type == null) {
-        throw new IllegalArgumentException("Type cannot be null");
+      if (type == null && stringType == null) {
+        throw new IllegalArgumentException("Atleast type or string type must be present.");
       }
 
       Value v = new Value();
       v.bytes = value;
-      v.isPrimitive = Types.isPrimitive(type);
-      v.type = Types.typeToString(type);
+      if (type != null) {
+        v.isPrimitive = Types.isPrimitive(type);
+        v.type = Types.typeToString(type);
+      } else {
+        v.type = stringType;
+      }
       return v;
     }
   }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,4 +1,13 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
+  }
+}
 apply plugin: 'com.android.application'
+apply plugin: 'com.neenbedankt.android-apt'
 apply from: "$project.rootDir/quality/quality.gradle"
 
 android {
@@ -37,4 +46,10 @@ dependencies {
   compile project(':eve')
   compile project(':eve-converters:converter-moshi')
   compile project(':eve-stores:store-sql')
+
+  //auto-value
+  apt 'com.google.auto.value:auto-value:1.2'
+  provided 'com.jakewharton.auto.value:auto-value-annotations:1.2-update1'
+  apt 'com.ryanharter.auto.value:auto-value-moshi:0.3.2'
+  apt 'com.ryanharter.auto.value:auto-value-parcel:0.2.1'
 }

--- a/sample/src/main/java/uncmn/eve/sample/MainActivity.java
+++ b/sample/src/main/java/uncmn/eve/sample/MainActivity.java
@@ -20,8 +20,8 @@ public class MainActivity extends AppCompatActivity {
 
     Moshi moshi = new Moshi.Builder().add(new AutoValueMoshiAdapterFactory()).build();
     MoshiConverter converter = MoshiConverter.create(moshi);
-    converter.addConverter(SampleObjectOne.CONVERTER_KEY, SampleObjectOne.class);
-    converter.addConverter(SampleObjectTwo.CONVERTER_KEY, SampleObjectTwo.class);
+    converter.map(SampleObjectOne.CONVERTER_KEY, SampleObjectOne.class);
+    converter.map(SampleObjectTwo.CONVERTER_KEY, SampleObjectTwo.class);
     SqlStore store = SqlStore.create(this, converter);
 
     eve = Eve.builder(this).store(store).build();

--- a/sample/src/main/java/uncmn/eve/sample/MainActivity.java
+++ b/sample/src/main/java/uncmn/eve/sample/MainActivity.java
@@ -2,6 +2,8 @@ package uncmn.eve.sample;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import com.ryanharter.auto.value.moshi.AutoValueMoshiAdapterFactory;
 import com.squareup.moshi.Moshi;
 import uncmn.eve.Eve;
 import uncmn.eve.converter.moshi.MoshiConverter;
@@ -9,20 +11,54 @@ import uncmn.eve.store.sql.SqlStore;
 
 public class MainActivity extends AppCompatActivity {
 
+  private static final String TAG = MainActivity.class.getSimpleName();
   Eve eve;
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
 
-    Moshi moshi = new Moshi.Builder().build();
-
-    SqlStore store = SqlStore.create(this, MoshiConverter.create(moshi));
+    Moshi moshi = new Moshi.Builder().add(new AutoValueMoshiAdapterFactory()).build();
+    MoshiConverter converter = MoshiConverter.create(moshi);
+    converter.addConverter(SampleObjectOne.CONVERTER_KEY, SampleObjectOne.class);
+    converter.addConverter(SampleObjectTwo.CONVERTER_KEY, SampleObjectTwo.class);
+    SqlStore store = SqlStore.create(this, converter);
 
     eve = Eve.builder(this).store(store).build();
 
     eve.store().set("hello", "hello");
     eve.store().set("hello", 1);
-    eve.store().print("hello");
+    int val = eve.store().get("hello");
+    Log.d(TAG, "Hello val is - " + val);
+
+    String complexKey1 = "complex1";
+    SampleObjectOne obj1 = SampleObjectOne.create(complexKey1, new float[] { 1f, 2.5f });
+    eve.store().set(complexKey1, obj1);
+
+    String complexKey2 = "complex2";
+    SampleObjectOne obj2 = SampleObjectOne.create(complexKey2, new float[] { 2f, 2.5f });
+    eve.store().set(complexKey2, obj2);
+
+    String complexKey3 = "complex3";
+    SampleObjectOne obj3 = SampleObjectOne.create(complexKey3, new float[] { 3f, 3.5f });
+    eve.store().set(complexKey3, obj3);
+
+    SampleObjectOne retObj3 = eve.store().get(complexKey3);
+    Log.d(TAG, "Is obj3 same ? " + obj3.equals(retObj3));
+
+    String sampleKey1 = "sample1";
+    SampleObjectTwo sample1 = SampleObjectTwo.create(sampleKey1, new int[] { 1, 2 });
+    eve.store().set(sampleKey1, sample1);
+
+    String sampleKey2 = "sample2";
+    SampleObjectTwo sample2 = SampleObjectTwo.create(sampleKey2, new int[] { 2, 3 });
+    eve.store().set(sampleKey2, sample2);
+
+    String sampleKey3 = "sample3";
+    SampleObjectTwo sample3 = SampleObjectTwo.create(sampleKey3, new int[] { 3, 4 });
+    eve.store().set(sampleKey3, sample3);
+
+    SampleObjectTwo retSample3 = eve.store().get(sampleKey3);
+    Log.d(TAG, "Is sample same ? " + sample3.equals(retSample3));
   }
 }

--- a/sample/src/main/java/uncmn/eve/sample/SampleObjectOne.java
+++ b/sample/src/main/java/uncmn/eve/sample/SampleObjectOne.java
@@ -1,0 +1,24 @@
+package uncmn.eve.sample;
+
+import com.google.auto.value.AutoValue;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+
+/**
+ * Complex object resource.
+ */
+@AutoValue public abstract class SampleObjectOne {
+  public static final String CONVERTER_KEY = "SampleObjectOne";
+
+  public abstract String name();
+
+  public abstract float[] items();
+
+  public static SampleObjectOne create(String name, float[] items) {
+    return new AutoValue_SampleObjectOne(name, items);
+  }
+
+  public static JsonAdapter<SampleObjectOne> jsonAdapter(Moshi moshi) {
+    return new AutoValue_SampleObjectOne.MoshiJsonAdapter(moshi);
+  }
+}

--- a/sample/src/main/java/uncmn/eve/sample/SampleObjectTwo.java
+++ b/sample/src/main/java/uncmn/eve/sample/SampleObjectTwo.java
@@ -1,0 +1,24 @@
+package uncmn.eve.sample;
+
+import com.google.auto.value.AutoValue;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+
+/**
+ * Complex object resource.
+ */
+@AutoValue public abstract class SampleObjectTwo {
+  public static final String CONVERTER_KEY = "SampleObjectTwo";
+
+  public abstract String name();
+
+  public abstract int[] items();
+
+  public static SampleObjectTwo create(String name, int[] items) {
+    return new AutoValue_SampleObjectTwo(name, items);
+  }
+
+  public static JsonAdapter<SampleObjectTwo> jsonAdapter(Moshi moshi) {
+    return new AutoValue_SampleObjectTwo.MoshiJsonAdapter(moshi);
+  }
+}


### PR DESCRIPTION
This merge requests completely avoids storing class names in key value store. It delegates class inspection logic to converters.

Converters are now needed to identify and map objects to a unique converter key.
